### PR TITLE
fix(angular): Conditionally display "Website" attribute on SAAS demo

### DIFF
--- a/demos/angular/saas/src/app/app.component.html
+++ b/demos/angular/saas/src/app/app.component.html
@@ -115,10 +115,8 @@
                       </ais-highlight>
                     </td>
                     <td>
-                      <span *ngIf="hit.Website">
-                        <ais-highlight attribute="Website" [hit]="hit">
-                        </ais-highlight>
-                      </span>
+                      <ais-highlight attribute="Website" [hit]="hit" *ngIf="hit.Website">
+                      </ais-highlight>
                     </td>
                     <td>
                       <ais-highlight attribute="Owner" [hit]="hit">

--- a/demos/angular/saas/src/app/app.component.html
+++ b/demos/angular/saas/src/app/app.component.html
@@ -115,8 +115,10 @@
                       </ais-highlight>
                     </td>
                     <td>
-                      <ais-highlight attribute="Website" [hit]="hit">
-                      </ais-highlight>
+                      <span *ngIf="hit.Website">
+                        <ais-highlight attribute="Website" [hit]="hit">
+                        </ais-highlight>
+                      </span>
                     </td>
                     <td>
                       <ais-highlight attribute="Owner" [hit]="hit">


### PR DESCRIPTION
Don't display the "Website" attribute if none since it makes CodeSandbox go crazy.