### PR TITLE
chore(deps): add renovate to pin deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["config:js-app", "algolia"]
+}


### PR DESCRIPTION
One tricky part of this project is to be sure the onboarding frontend
code is always working. For this we should have every PR commented with
updated CodeSandbox links to be opened for test (to ensure the
CodeSandbox preview will be working).

This PR is not about the test but about pining dependencies for the
whole repo so that there's no automatic upgrade and if a new version of
InstantSearch is pushed, it will never break the doc onboarding code,
but if we merge renovate upgrades.