### PR TITLE
fix(Facet): avoid to unmount the RefinementList when no results from SFFV

### DIFF
--- a/demos/react/ecommerce/src/App.css
+++ b/demos/react/ecommerce/src/App.css
@@ -256,7 +256,8 @@ a {
   margin-bottom: 16px;
 }
 
-.ais-RefinementList-item {
+.ais-RefinementList-item,
+.ais-RefinementList-noResults {
   padding: 8px 16px;
 }
 

--- a/demos/react/ecommerce/src/Facet.js
+++ b/demos/react/ecommerce/src/Facet.js
@@ -1,9 +1,9 @@
 import React from "react";
-import { RefinementList } from "react-instantsearch-dom";
-import { connectRefinementList } from "react-instantsearch/connectors";
+import { RefinementList, connectRefinementList } from "react-instantsearch-dom";
+
 export default connectRefinementList(
-  ({ translations, searchable, attribute, items }) =>
-    items.length && items.length > 0 ? (
+  ({ translations, searchable, attribute, items, isFromSearch }) =>
+    isFromSearch || (items.length && items.length > 0) ? (
       <RefinementList
         attribute={attribute}
         searchable={searchable}


### PR DESCRIPTION
**Summary**

With the current implementation when the search for facet values (SFFV) don't return any results we unmount the `RefinementList`. It means that the current state of the widget is lost and the user will never be able to see the "no results" message. The PR fix the issue by checking whether or not the `items` are coming from SFFV.

**Before**

![before](https://user-images.githubusercontent.com/6513513/42154044-11e5c5dc-7de5-11e8-8640-8982b3ebee20.gif)

**After**

![after](https://user-images.githubusercontent.com/6513513/42154094-3174a94a-7de5-11e8-80e3-a9531ee1817e.gif)